### PR TITLE
[SYM-5417] Support Google Secrets Manager Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_accessible_secrets"></a> [accessible\_secrets](#input\_accessible\_secrets) | A map of google\_secret\_manager\_secret objects to grant the Sym Integration read-only access to. | <pre>list(object({<br>    project   = string<br>    secret_id = string<br>    name      = string<br>  }))</pre> | `null` | no |
+| <a name="input_accessible_secrets"></a> [accessible\_secrets](#input\_accessible\_secrets) | A map of google\_secret\_manager\_secret objects to grant the Sym Integration read-only access to. | <pre>list(object({<br>    project   = string<br>    secret_id = string<br>    name      = string<br>  }))</pre> | `[]` | no |
 | <a name="input_enable_google_group_management"></a> [enable\_google\_group\_management](#input\_enable\_google\_group\_management) | A boolean indicating whether to enable the Admin SDK API to allow the Sym Integration to manage Google Group membership. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | An environment qualifier for the resources this module creates, e.g. staging, or prod. | `string` | n/a | yes |
 | <a name="input_gcp_org_id"></a> [gcp\_org\_id](#input\_gcp\_org\_id) | The Organization ID of your Google Cloud Organization | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ module "gcp_connector" {
   identity_pool_project_id = "my-project-id"
   gcp_org_id               = "123456789"
 
+  # Enable the Admin SDK API if managing Google Group membership
   enable_google_group_management = true
+  
+  # A list of Google Secret Manager secrets to which the Sym Runtime may have read-only access
+  accessible_secrets = [google_secret_manager_secret.okta_api_key]
 }
 ```
 
@@ -64,8 +68,10 @@ No modules.
 | [google_project_service.admin_sdk_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.iam_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.resource_manager_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.secretmanager_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.service_account_credentials_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.sts_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_secret_manager_secret_iam_member.secret_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_service_account.sym](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [sym_integration.google_workload_identity_federation](https://registry.terraform.io/providers/symopsio/sym/latest/docs/resources/integration) | resource |
@@ -76,6 +82,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_accessible_secrets"></a> [accessible\_secrets](#input\_accessible\_secrets) | A map of google\_secret\_manager\_secret objects to grant the Sym Integration read-only access to. | <pre>list(object({<br>    project   = string<br>    secret_id = string<br>    name      = string<br>  }))</pre> | `null` | no |
 | <a name="input_enable_google_group_management"></a> [enable\_google\_group\_management](#input\_enable\_google\_group\_management) | A boolean indicating whether to enable the Admin SDK API to allow the Sym Integration to manage Google Group membership. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | An environment qualifier for the resources this module creates, e.g. staging, or prod. | `string` | n/a | yes |
 | <a name="input_gcp_org_id"></a> [gcp\_org\_id](#input\_gcp\_org\_id) | The Organization ID of your Google Cloud Organization | `any` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,30 @@ resource "google_project_service" "admin_sdk_api" {
   disable_dependent_services = false
 }
 
+######## Google Secret Manager Secrets Access Resources
+# Enable the Secret Manager API in the Workload Identity Pool Project
+resource "google_project_service" "secretmanager_api" {
+  count = var.accessible_secrets ? 1 : 0
+
+  project = data.google_project.sym_integration.project_id
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}
+
+# For each given secret, grant the Sym Service Account the secretAccessor role.
+resource "google_secret_manager_secret_iam_member" "secret_reader" {
+  for_each = { # Can't for-each over a list of objects, so converting it to a map of unique names to secret objects
+    for _, secret in var.accessible_secrets : secret.name => secret
+  }
+
+  project   = each.value.project
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.sym.email}"
+  secret_id = each.value.secret_id
+}
+
 ######## Sym Resources
 
 # Create a sym_integration for the created Google Workload Identity Federation resources.

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "accessible_secrets" {
     secret_id = string
     name      = string
   }))
-  default = null
+  default = []
 }
 
 variable "sym_account_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,16 @@ variable "enable_google_group_management" {
   default     = false
 }
 
+variable "accessible_secrets" {
+  description = "A map of google_secret_manager_secret objects to grant the Sym Integration read-only access to."
+  type = list(object({
+    project   = string
+    secret_id = string
+    name      = string
+  }))
+  default = null
+}
+
 variable "sym_account_id" {
   description = "The AWS account ID that can impersonate the created Google service account. Defaults to the Sym Production AWS account ID."
   type        = string


### PR DESCRIPTION
## Description
- Adds a new variable `accessible_secrets`, which contains a list of objects in the shape of a `google_secret_manager_secret` resource.
- If the list is non-null, then enables the Secret Manager API in the Workload Identity Pool Project
- For each secret in the list, grant the Sym Service Account the `secretmanager.secretAccessor` role (a read-only role)
  - https://cloud.google.com/secret-manager/docs/access-control#secretmanager.secretAccessor

## Testing
Tested with `v1.1.0-alpha2` with the following configuration in `sym-staging/gcp-connector`

```terraform
resource "google_secret_manager_secret" "okta_api_key" {
  project = "sym-wif-pools"

  secret_id = "staging_okta-api-key"

  replication {
    auto {}
  }
}

# To apply this module, log in with `gcloud auth application-default login` as admin@compliance.dev
module "gcp_connector" {
  source  = "symopsio/gcp-connector/google"
  version = "1.1.0-alpha2"

  environment              = "sym-staging"
  identity_pool_project_id = "sym-wif-pools"
  gcp_org_id               = "472792873457"

  enable_google_group_management = true

  sym_account_id  = "455753951875" # Staging AWS account
  sym_runtime_arn = "arn:aws:sts::455753951875:assumed-role/phoenix-staging-runtime/phoenix-staging-runtime"

  accessible_secrets = [google_secret_manager_secret.okta_api_key]
}
```
### Output
```terraform
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_secret_manager_secret.okta_api_key will be created
  + resource "google_secret_manager_secret" "okta_api_key" {
      + create_time           = (known after apply)
      + effective_annotations = (known after apply)
      + effective_labels      = (known after apply)
      + expire_time           = (known after apply)
      + id                    = (known after apply)
      + name                  = (known after apply)
      + project               = "sym-wif-pools"
      + secret_id             = "staging_okta-api-key"
      + terraform_labels      = (known after apply)

      + replication {
          + auto {
            }
        }
    }

  # module.gcp_connector.google_project_service.secretmanager_api[0] will be created
  + resource "google_project_service" "secretmanager_api" {
      + disable_dependent_services = false
      + disable_on_destroy         = false
      + id                         = (known after apply)
      + project                    = "sym-wif-pools"
      + service                    = "secretmanager.googleapis.com"
    }

  # module.gcp_connector.google_secret_manager_secret_iam_member.secret_reader["sym-wif-pools/staging_okta-api-key"] will be created
  + resource "google_secret_manager_secret_iam_member" "secret_reader" {
      + etag      = (known after apply)
      + id        = (known after apply)
      + member    = "serviceAccount:sym-integration-sym-staging@sym-wif-pools.iam.gserviceaccount.com"
      + project   = "sym-wif-pools"
      + role      = "roles/secretmanager.secretAccessor"
      + secret_id = "staging_okta-api-key"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_secret_manager_secret.okta_api_key: Creating...
google_secret_manager_secret.okta_api_key: Creation complete after 0s [id=projects/sym-wif-pools/secrets/staging_okta-api-key]
module.gcp_connector.google_secret_manager_secret_iam_member.secret_reader["sym-wif-pools/staging_okta-api-key"]: Creating...
module.gcp_connector.google_project_service.secretmanager_api[0]: Creating...
module.gcp_connector.google_project_service.secretmanager_api[0]: Creation complete after 4s [id=sym-wif-pools/secretmanager.googleapis.com]
module.gcp_connector.google_secret_manager_secret_iam_member.secret_reader["sym-wif-pools/staging_okta-api-key"]: Creation complete after 5s [id=projects/sym-wif-pools/secrets/staging_okta-api-key/roles/secretmanager.secretAccessor/serviceAccount:sym-integration-sym-staging@sym-wif-pools.iam.gserviceaccount.com]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

### Tested with a data resource, where the secret is in a different project from the service account
```terraform
data "google_secret_manager_secret" "different_project_secret" {
  project = "main-project-407214"
  secret_id = "sym_staging-manual-secret"
}

# To apply this module, log in with `gcloud auth application-default login` as admin@compliance.dev
module "gcp_connector" {
  source  = "symopsio/gcp-connector/google"
  version = "1.1.0-alpha2"

  environment              = "sym-staging"
  identity_pool_project_id = "sym-wif-pools"
  gcp_org_id               = "472792873457"

  enable_google_group_management = true

  sym_account_id  = "455753951875" # Staging AWS account
  sym_runtime_arn = "arn:aws:sts::455753951875:assumed-role/phoenix-staging-runtime/phoenix-staging-runtime"

  accessible_secrets = [google_secret_manager_secret.okta_api_key, data.google_secret_manager_secret.different_project_secret]
}
```

```terraform
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.gcp_connector.google_secret_manager_secret_iam_member.secret_reader["main-project-407214/sym_staging-manual-secret"] will be created
  + resource "google_secret_manager_secret_iam_member" "secret_reader" {
      + etag      = (known after apply)
      + id        = (known after apply)
      + member    = "serviceAccount:sym-integration-sym-staging@sym-wif-pools.iam.gserviceaccount.com"
      + project   = "main-project-407214"
      + role      = "roles/secretmanager.secretAccessor"
      + secret_id = "sym_staging-manual-secret"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.gcp_connector.google_secret_manager_secret_iam_member.secret_reader["main-project-407214/sym_staging-manual-secret"]: Creating...
module.gcp_connector.google_secret_manager_secret_iam_member.secret_reader["main-project-407214/sym_staging-manual-secret"]: Creation complete after 4s [id=projects/main-project-407214/secrets/sym_staging-manual-secret/roles/secretmanager.secretAccessor/serviceAccount:sym-integration-sym-staging@sym-wif-pools.iam.gserviceaccount.com]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Confirmed that the Sym Service account has the Secrets Accessor Role
![Screenshot 2024-01-09 at 3 18 31 PM](https://github.com/symopsio/terraform-google-gcp-connector/assets/10479740/eb05586e-e596-4f80-a269-3811d657e40b)
![Screenshot 2024-01-09 at 3 21 07 PM](https://github.com/symopsio/terraform-google-gcp-connector/assets/10479740/7a3869ee-3556-40cf-a982-de9085e8d7c5)

